### PR TITLE
Add cached layout for containers

### DIFF
--- a/Agent.Core/Gameplay/Container.cs
+++ b/Agent.Core/Gameplay/Container.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Agent.Core.Gameplay
+{
+    /// <summary>
+    /// Generic base container that exposes all properties decorated with
+    /// <see cref="ContainerPropertyAttribute"/> as enumerable slot/value pairs.
+    /// </summary>
+    public abstract class Container<T> : IEnumerable<(ISlotDescriptor Slot, T Value)>
+    {
+        private readonly (ISlotDescriptor Slot, PropertyInfo Property)[] _layout;
+
+        protected Container()
+        {
+            _layout = GetLayout(GetType());
+        }
+
+        private static readonly ConcurrentDictionary<Type, (ISlotDescriptor Slot, PropertyInfo Property)[]> _layouts = new();
+
+        private static (ISlotDescriptor Slot, PropertyInfo Property)[] GetLayout(Type type)
+        {
+            return _layouts.GetOrAdd(type, t =>
+            {
+                var props = t.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+                var list = new List<(ISlotDescriptor Slot, PropertyInfo Property)>();
+                foreach (var prop in props)
+                {
+                    var attr = prop.GetCustomAttribute<ContainerPropertyAttribute>();
+                    if (attr != null && prop.PropertyType == typeof(T))
+                    {
+                        list.Add((attr.Slot, prop));
+                    }
+                }
+
+                return list.ToArray();
+            });
+        }
+
+        public IEnumerator<(ISlotDescriptor Slot, T Value)> GetEnumerator()
+        {
+            foreach (var (slot, property) in _layout)
+            {
+                var value = (T)(property.GetValue(this) ?? default(T));
+                yield return (slot, value);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Agent.Core/Gameplay/ContainerPropertyAttribute.cs
+++ b/Agent.Core/Gameplay/ContainerPropertyAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Agent.Core.Gameplay
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ContainerPropertyAttribute : Attribute
+    {
+        public SlotDescriptor Slot { get; }
+
+        public ContainerPropertyAttribute(string name)
+        {
+            Slot = new SlotDescriptor(name);
+        }
+    }
+}

--- a/Agent.Core/Gameplay/SlotDescriptor.cs
+++ b/Agent.Core/Gameplay/SlotDescriptor.cs
@@ -1,0 +1,17 @@
+namespace Agent.Core.Gameplay
+{
+    public interface ISlotDescriptor
+    {
+        string Name { get; }
+    }
+
+    public readonly struct SlotDescriptor : ISlotDescriptor
+    {
+        public string Name { get; }
+
+        public SlotDescriptor(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/Agent.Core/Gameplay/StatsContainer.cs
+++ b/Agent.Core/Gameplay/StatsContainer.cs
@@ -1,0 +1,17 @@
+namespace Agent.Core.Gameplay
+{
+    /// <summary>
+    /// Simple container of floating point stats.
+    /// </summary>
+    public class StatsContainer : Container<float>
+    {
+        [ContainerProperty("strength")]
+        public float Strength { get; set; }
+
+        [ContainerProperty("intelligence")]
+        public float Intelligence { get; set; }
+
+        [ContainerProperty("dexterity")]
+        public float Dexterity { get; set; }
+    }
+}

--- a/Agent.Test/Agent.Test.csproj
+++ b/Agent.Test/Agent.Test.csproj
@@ -4,6 +4,18 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Agent.Core\Agent.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Agent.Test/GlobalUsings.cs
+++ b/Agent.Test/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/Agent.Test/StatsContainerTests.cs
+++ b/Agent.Test/StatsContainerTests.cs
@@ -1,0 +1,25 @@
+using System;
+using Agent.Core.Gameplay;
+
+namespace Agent.Tests
+{
+    [TestFixture]
+    public class StatsContainerTests
+    {
+        [Test]
+        public void IterateStats_PrintsNameAndValue()
+        {
+            var container = new StatsContainer
+            {
+                Strength = 5,
+                Intelligence = 7,
+                Dexterity = 9
+            };
+
+            foreach (var (slot, value) in container)
+            {
+                Console.WriteLine($"{slot.Name}: {value}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cache property layout using a ConcurrentDictionary
- store the cached layout in the container constructor

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*